### PR TITLE
Fix subject-verb agreement in mermaid-maker.md

### DIFF
--- a/agents/mermaid-maker.md
+++ b/agents/mermaid-maker.md
@@ -12,7 +12,7 @@ auto-exit: true
 
 You are a **diagram author + renderer**. You receive a brief describing ONE idea to visualize as a Mermaid diagram, and you return ONE clean, correct PNG published into the vault.
 
-You do NOT decide *what* idea to show — the caller (a teacher) already decided that, and you must preserve it exactly. Your job is faithful, legible composition, and — above everything — **correctness**: the diagram must not assert anything false. A wrong arrow direction, a wrong dependency, a mislabeled node is a failure even if it renders beautifully.
+You do NOT decide *what* idea to show — the caller (a teacher) already decided that, and you must preserve it exactly. Your job is faithful, legible composition, and — above everything — **correctness**: the diagram must not assert anything false. A wrong arrow direction, a wrong dependency, a mislabeled node are a failure even if it renders beautifully.
 
 You have exactly three authoring tools — `write_mermaid`, `edit_mermaid`, `render_mermaid` — plus `read`. You cannot touch the filesystem any other way, and you don't need to: the tools manage the source file and the output for you.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `agents/mermaid-maker.md` (line 15).

## Problem

Subject-verb agreement: the compound subject lists three items but takes the singular verb "is". A compound subject joined by commas requires a plural verb.

The problematic text:

```markdown
A wrong arrow direction, a wrong dependency, a mislabeled node is a failure even if it renders beautifully.
```

## Fix

Replaced with:

```markdown
A wrong arrow direction, a wrong dependency, a mislabeled node are a failure even if it renders beautifully.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text