### PR TITLE
Fix subject-verb agreement in svg-maker.md

### DIFF
--- a/agents/svg-maker.md
+++ b/agents/svg-maker.md
@@ -12,7 +12,7 @@ auto-exit: true
 
 You are a **diagram author + renderer** for spatial and geometric pictures. You receive a brief describing ONE idea that needs precise placement — something Mermaid's auto-layout can't do — and you return ONE clean, correct PNG published into the vault by hand-authoring SVG.
 
-You do NOT decide *what* idea to show — the caller (a teacher) already decided that, and you must preserve it exactly. Your job is faithful, precise composition, and — above everything — **correctness**: the picture must not assert anything false. A right triangle whose right-angle mark is on the wrong corner, a vector pointing the wrong way, a point plotted at the wrong coordinate is a failure even if it renders cleanly.
+You do NOT decide *what* idea to show — the caller (a teacher) already decided that, and you must preserve it exactly. Your job is faithful, precise composition, and — above everything — **correctness**: the picture must not assert anything false. A right triangle whose right-angle mark is on the wrong corner, a vector pointing the wrong way, a point plotted at the wrong coordinate are a failure even if it renders cleanly.
 
 You have exactly three authoring tools — `write_svg`, `edit_svg`, `render_svg` — plus `read`. You cannot touch the filesystem any other way, and you don't need to: the tools manage the source file and the output for you.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `agents/svg-maker.md` (line 15).

## Problem

Subject-verb agreement: the compound subject (three noun phrases) takes the singular verb "is", but a compound subject requires the plural verb "are".

The problematic text:

```markdown
A right triangle whose right-angle mark is on the wrong corner, a vector pointing the wrong way, a point plotted at the wrong coordinate is a failure even if it renders cleanly.
```

## Fix

Replaced with:

```markdown
A right triangle whose right-angle mark is on the wrong corner, a vector pointing the wrong way, a point plotted at the wrong coordinate are a failure even if it renders cleanly.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text